### PR TITLE
Build pip and gem packages using the default compiler arch on macOS

### DIFF
--- a/ice/gem/extconf.rb
+++ b/ice/gem/extconf.rb
@@ -26,11 +26,7 @@ if RUBY_PLATFORM =~ /linux/
     end
 end
 
-#
-# Ice on OSX is built only with 64 bit support.
-#
 if RUBY_PLATFORM =~ /darwin/
-    $ARCH_FLAG = "-arch x86_64"
     # Make sure to use the SDK from Xcode (required for Sierra where old system headers can be used otherwise)
     RbConfig::MAKEFILE_CONFIG['CC'] = 'xcrun -sdk macosx clang'
     RbConfig::MAKEFILE_CONFIG['CXX'] = 'xcrun -sdk macosx clang++'

--- a/ice/pypi/setup.py
+++ b/ice/pypi/setup.py
@@ -75,8 +75,6 @@ else:
     define_macros+=[('ICE_STATIC_LIBS', None)]
 
 if platform == 'darwin':
-    if not 'ARCHFLAGS' in os.environ:
-        os.environ['ARCHFLAGS'] = '-arch x86_64'
     # Make sure to use the SDK from Xcode (required for Sierra where old system headers can be used otherwise)
     os.environ['CC'] = 'xcrun -sdk macosx clang'
     os.environ['CXX'] = 'xcrun -sdk macosx clang++'


### PR DESCRIPTION
Fix #23